### PR TITLE
getTopStackInfo移动到msg前面，避免因tag过长导致无法打印tag

### DIFF
--- a/library/src/main/java/com/apkfuns/logutils/LogConfigImpl.java
+++ b/library/src/main/java/com/apkfuns/logutils/LogConfigImpl.java
@@ -95,7 +95,7 @@ class LogConfigImpl implements LogConfig {
 
     public String getTagPrefix() {
         if (TextUtils.isEmpty(tagPrefix)) {
-            return "LogUtils-";
+            return "LogUtils";
         }
 
         return tagPrefix;

--- a/library/src/main/java/com/apkfuns/logutils/Logger.java
+++ b/library/src/main/java/com/apkfuns/logutils/Logger.java
@@ -130,13 +130,7 @@ class Logger implements Printer {
         String tempTag = localTags.get();
         if (!TextUtils.isEmpty(tempTag)) {
             localTags.remove();
-            if (mLogConfig.isShowBorder()) {
-                return tempTag;
-            }
             return tempTag + "/" + getTopStackInfo();
-        }
-        if (!mLogConfig.isShowBorder()) {
-            return mLogConfig.getTagPrefix() + "/" + getTopStackInfo();
         }
         return mLogConfig.getTagPrefix();
     }
@@ -316,6 +310,7 @@ class Logger implements Printer {
      * @param msg
      */
     private void printLog(@LogLevelType int type, String tag, String msg) {
+        msg = getTopStackInfo()+": "+msg;
         switch (type) {
             case TYPE_VERBOSE:
                 Log.v(tag, msg);


### PR DESCRIPTION
请检查这里的改动对其他格式化的log是否会产生影响。（比如表格样式的log）
我简单看了下，应该不会影响。
如有影响请反馈。