### PR TITLE
添加hugo来判断 performance

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,16 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.jakewharton.hugo:hugo-plugin:1.2.1'
+    }
+}
+
 apply plugin: 'com.android.application'
+apply plugin: 'com.jakewharton.hugo'
+
 
 android {
     compileSdkVersion 21

--- a/app/src/main/java/com/apkfuns/logutils/demo/App.java
+++ b/app/src/main/java/com/apkfuns/logutils/demo/App.java
@@ -14,7 +14,7 @@ public class App extends Application {
     public void onCreate() {
         super.onCreate();
         LogUtils.getLogConfig()
-                .configAllowLog(true)
+                .configAllowLog(false)
                 .configTagPrefix("LogUtilsDemo")
                 .configFormatTag("%d{HH:mm:ss:SSS} %t %c{-5}")
                 .configShowBorders(true)

--- a/app/src/main/java/com/apkfuns/logutils/demo/activity/MainActivity.java
+++ b/app/src/main/java/com/apkfuns/logutils/demo/activity/MainActivity.java
@@ -4,30 +4,37 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
+import com.apkfuns.logutils.LogUtils;
+import com.apkfuns.logutils.demo.R;
 import com.apkfuns.logutils.demo.a.b.Test;
 import com.apkfuns.logutils.demo.helper.Child;
 import com.apkfuns.logutils.demo.helper.DataHelper;
-import com.apkfuns.logutils.LogUtils;
-import com.apkfuns.logutils.demo.R;
 import com.apkfuns.logutils.demo.model.FakeBounty;
 import com.apkfuns.logutils.demo.model.Man;
 import com.apkfuns.logutils.demo.model.MulObject;
 import com.apkfuns.logutils.demo.model.Person;
-
 
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import hugo.weaving.DebugLog;
+
 
 public class MainActivity extends Activity {
 
+    @DebugLog
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
+        log();
+    }
+
+    @DebugLog
+    private void log() {
         LogUtils.d("12345");
         LogUtils.d("12%s3%s45", "a", "b");
         LogUtils.d(new NullPointerException("12345"));


### PR DESCRIPTION
我为了不影响release 版本的效率，我通过config 把log关闭，然后再使用hugo 简单做了一下性能测试，发现即使关闭了log，它还会去判断 该怎么打印 log，这会花费很多时间。我在MainActivity里，onCreate一共花费了140ms，但是132ms是耗费在log里。这里可以做一做优化。